### PR TITLE
refactor!: make Unitful a weak dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **Breaking**: Replace `SignalAnalysis` spectrogram configuration with `DSP` keyword arguments in `pspectrum`; use `nfft`, `noverlap`, and `window` keywords instead of a positional config object.
 - **Breaking**: `pspectrum` now stores spectrogram `DimArray` output as `(frequency, time)` to match `DSP.spectrogram` layout.
 - `pspectrum` no longer uses `Unitful` internally for sampling rate and time-bin conversion.
+- `Unitful` is now a weak dependency; `current_density` returns plain numeric output for numeric input and unitful output when Unitful quantities are loaded.
 
 ## [0.2.2] - 2025-11-23
 

--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,14 @@ MultiSpacecraftAnalysis = "162efcab-a561-4df9-ac40-20243229ff2c"
 PlasmaWaves = "12efb907-3f94-4823-94fe-a707db5a5005"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SpaceDataModel = "0b37b92c-f0c5-4a52-bd5c-390dec20857c"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 TimeseriesUtilities = "31d49243-0742-49c1-b8d2-db113b74581e"
+
+[weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
+[extensions]
+SPEDASUnitfulExt = "Unitful"
 
 [compat]
 DSP = "0.8"
@@ -35,8 +39,7 @@ MultiSpacecraftAnalysis = "0.1.1"
 PlasmaWaves = "0.1.1"
 Reexport = "1"
 SpaceDataModel = "0.2.3"
-StaticArrays = "1"
 TOML = "1"
-TimeseriesUtilities = "0.1.5"
+TimeseriesUtilities = "0.2"
 Unitful = "1"
 julia = "1.10"

--- a/ext/SPEDASUnitfulExt.jl
+++ b/ext/SPEDASUnitfulExt.jl
@@ -1,0 +1,12 @@
+module SPEDASUnitfulExt
+
+using Unitful: Unitful, μ0, upreferred
+using SPEDAS: SPEDAS, _current_density
+
+@views function SPEDAS.current_density(B::AbstractArray{<:Unitful.AbstractQuantity}, V::AbstractArray{<:Unitful.AbstractQuantity})
+    return _current_density(B, V) do dBdt, Vz
+        @. upreferred(dBdt / (μ0 * Vz))
+    end
+end
+
+end

--- a/src/SPEDAS.jl
+++ b/src/SPEDAS.jl
@@ -13,9 +13,8 @@ using DimensionalData: AbstractDimVector, TimeDim
 using DimensionalData.Dimensions: Dimension
 using DSP: spectrogram, hamming
 using LinearAlgebra
-using StaticArrays
-using Unitful
 using Reexport: @reexport
+import TimeseriesUtilities: ContinuousTimeRanges
 @reexport using SpaceDataModel
 using SpaceDataModel: meta, name, setmeta, NoMetadata, NoData, timedim, tdimnum, times, unwrap
 import SpaceDataModel as SDM
@@ -35,7 +34,6 @@ const DD = DimensionalData
 include("projects/project.jl")
 include("timeseries/spectrum.jl")
 include("timeseries/gap.jl")
-include("utils.jl")
 include("utils/dimensiondata.jl")
 include("resampling/resample.jl")
 include("cotrans/cotrans.jl")

--- a/src/analysis/current_density.jl
+++ b/src/analysis/current_density.jl
@@ -1,29 +1,37 @@
-using Unitful: μ0
-
 """
     current_density(B, V)
 
-Calculate the current density time series from the magnetic field (B) and plasma velocity (V) time series.
+Calculate the current density time series from magnetic field (B) and plasma velocity (V) time series.
 
 Assume 1-D structure along the z-direction. Remember to transform the coordinates of B and V first (e.g. using [`mva`](@ref)
 """
-@views function current_density(B, V)
+function current_density(B, V)
+    μ0 = 4π * 1.0e-7
+    return _current_density(B, V) do dBdt, Vz
+        @. dBdt / (μ0 * Vz)
+    end
+end
+
+function _current_density(f, B, V)
     _B_in, _V_in = tviews(B, V)
     ts = times(_B_in)
 
-    dBdt = tderiv(parent(_B_in), ts)
-    dBxdt = dBdt[:, 1]
-    dBydt = dBdt[:, 2]
-    Vz = tinterp(_V_in[:, 3], ts[1:end-1])
+    Bx = parent(_B_in)[:, 1]
+    By = parent(_B_in)[:, 2]
+    dBxdt = tderiv(Bx, ts)
+    dBydt = tderiv(By, ts)
+    Vz = tinterp(_V_in[:, 3], ts[1:(end - 1)])
 
-    Jx = @. upreferred(dBydt / (μ0 * Vz))
-    Jy = @. upreferred(-dBxdt / (μ0 * Vz))
+    Jx = f(dBydt, Vz)
+    Jy = f(-dBxdt, Vz)
 
-    B_in = _B_in[1:end-1, :]
-    Bx = B_in[:, 1]
-    By = B_in[:, 2]
-    Bmag = norm.(eachrow(B_in))
-    Jpara = @. (Jx * Bx + Jy * By) / Bmag
-    Jperp = @. (Jy * Bx - Jx * By) / Bmag
+    @views begin
+        B_in = _B_in[1:(end - 1), :]
+        Bx = B_in[:, 1]
+        By = B_in[:, 2]
+        Bmag = norm.(eachrow(B_in))
+        Jpara = @. (Jx * Bx + Jy * By) / Bmag
+        Jperp = @. (Jy * Bx - Jx * By) / Bmag
+    end
     return (; Jx, Jy, Jpara, Jperp)
 end

--- a/test/analysis/current_density.jl
+++ b/test/analysis/current_density.jl
@@ -1,0 +1,29 @@
+@testitem "current_density numeric" begin
+    using Dates
+    using DimensionalData
+
+    ts = DateTime(2020):Second(1):DateTime(2020) + Second(4)
+    B = DimArray(hcat(ones(5), 0:4, zeros(5)), (Ti(ts), Dim{:comp}([:x, :y, :z])))
+    V = DimArray(hcat(zeros(5), zeros(5), ones(5)), (Ti(ts), Dim{:comp}([:x, :y, :z])))
+
+    out = current_density(B, V)
+
+    @test out.Jx[1] ≈ 1 / (4π * 1e-7)
+    @test out.Jx[1] isa Float64
+end
+
+@testitem "current_density unitful" begin
+    using Dates
+    using DimensionalData
+    using Unitful
+
+    ts = DateTime(2020):Second(1):DateTime(2020) + Second(4)
+    B = DimArray(hcat(ones(5), 0:4, zeros(5)) .* u"nT", (Ti(ts), Dim{:comp}([:x, :y, :z])))
+    V = DimArray(hcat(zeros(5), zeros(5), ones(5)) .* u"km/s", (Ti(ts), Dim{:comp}([:x, :y, :z])))
+
+    out = current_density(B, V)
+    expected = uconvert(u"nA/m^2", (1u"nT/s") / (Unitful.μ0 * 1u"km/s"))
+
+    @test uconvert(u"nA/m^2", out.Jx[1]) ≈ expected
+    @test Unitful.dimension(out.Jx[1]) == Unitful.dimension(1u"A/m^2")
+end


### PR DESCRIPTION
BREAKING CHANGE: Unitful is no longer a direct dependency. current_density returns numeric output for numeric inputs; Unitful quantity inputs are handled by SPEDASUnitfulExt.
